### PR TITLE
Database restructure

### DIFF
--- a/src/components/BoardPage/Column/index.tsx
+++ b/src/components/BoardPage/Column/index.tsx
@@ -36,7 +36,6 @@ export default function Column({
   }
 
   function onChangeHandler(value: string) {
-    console.log('onchange', value);
     if (isEditingTitle) {
       setEditedTitle(value);
     }

--- a/src/components/BoardPage/ModalPortal/index.tsx
+++ b/src/components/BoardPage/ModalPortal/index.tsx
@@ -1,18 +1,18 @@
-import { useRef, useEffect, useState, useCallback } from 'react';
-import { createPortal } from 'react-dom';
-import { useModal } from '../../../context/ModalContext';
 import marked from 'marked';
-import AutoResizableTextarea from '../AutoResizableTextarea';
-import { CloseIcon } from '../../Icons';
-import styles from './modalportal.module.css';
-import FormatingHelp from '../FormatingHelp';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Card } from '../../../context/CardsContext';
 import { List } from '../../../context/ListsContext';
+import { useModal } from '../../../context/ModalContext';
+import { CloseIcon } from '../../Icons';
+import AutoResizableTextarea from '../AutoResizableTextarea';
+import FormatingHelp from '../FormatingHelp';
+import styles from './modalportal.module.css';
 
 interface ModalPortal {
   getList: (value: string) => List;
   getCard: (value: string) => Card;
-  updateCardData: (newData: Card) => void;
+  updateCardData: (cardId: string, title: string, description: string) => void;
 }
 
 function ModalPortal({ getCard, getList, updateCardData }: ModalPortal) {
@@ -55,7 +55,7 @@ function ModalPortal({ getCard, getList, updateCardData }: ModalPortal) {
   function hideModalHandle() {
     // setEditingDesc(false);
     if (window.confirm('Do you want to save your changes?')) {
-      updateCardData(cardData);
+      updateCardData(cardData.id, cardData.name, cardData.description);
     }
     hideModal();
   }

--- a/src/pages/api/boards/index.ts
+++ b/src/pages/api/boards/index.ts
@@ -6,6 +6,13 @@ import { BOARDS_COLLECTION } from '../../../utils/constants';
 import { find, insert } from '../../../utils/database';
 import { sessionReturn } from './../../../utils/interfaces';
 
+interface postBody {
+  title: string;
+  bgColor: string;
+  author: string;
+  isPublic: boolean;
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -15,8 +22,7 @@ export default async function handler(
 
   switch (requestType) {
     case 'POST': {
-      const { title, bgColor, lists, cards, author, isPublic } =
-        req.body as Board;
+      const { title, bgColor, author, isPublic } = req.body as postBody;
 
       if (!author) {
         res.status(400).send({ error: 'Missing author' });

--- a/src/pages/api/boards/index.ts
+++ b/src/pages/api/boards/index.ts
@@ -35,7 +35,6 @@ export default async function handler(
         title: title ?? 'My board',
         bgcolor: bgColor ?? 'rgb(210, 144, 52)',
         permissionList: [],
-        lists: lists ?? [],
         cards: cards ?? [],
         author: new ObjectId(session.user.userId),
         isPublic: isPublic || false,

--- a/src/pages/api/boards/index.ts
+++ b/src/pages/api/boards/index.ts
@@ -35,7 +35,6 @@ export default async function handler(
         title: title ?? 'My board',
         bgcolor: bgColor ?? 'rgb(210, 144, 52)',
         permissionList: [],
-        cards: cards ?? [],
         author: new ObjectId(session.user.userId),
         isPublic: isPublic || false,
       };

--- a/src/pages/boards/[slug].tsx
+++ b/src/pages/boards/[slug].tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { getSession, useSession } from 'next-auth/client';
-import { useRouter } from 'next/router';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import {
   DragDropContext,
@@ -9,14 +9,13 @@ import {
   Droppable,
   resetServerContext,
 } from 'react-beautiful-dnd';
-
 import AddList from '../../components/BoardPage/AddList';
 import Card from '../../components/BoardPage/Card';
 import Column from '../../components/BoardPage/Column';
 import ColumnHeader from '../../components/BoardPage/ColumnHeader';
 import ModalPortal from '../../components/BoardPage/ModalPortal';
 import { Board, useBoard } from '../../context/BoardContext';
-import { Card as ICard, useCards } from '../../context/CardsContext';
+import { useCards } from '../../context/CardsContext';
 import { useList } from '../../context/ListsContext';
 import { useModal } from '../../context/ModalContext';
 import styles from '../../styles/Board.module.css';
@@ -47,7 +46,14 @@ export default function BoardSlug({
     isPublic: isPublicContext,
     deleteBoard,
   } = useBoard();
-  const { createList, putLists, currentList, moveList, getList } = useList();
+  const {
+    createList,
+    putLists,
+    currentList,
+    moveList,
+    getList,
+    changeListTitle,
+  } = useList();
   const {
     createInitialCard,
     putCards,
@@ -66,12 +72,16 @@ export default function BoardSlug({
     }
   }, [cards, lists]);
 
-  function updateCardHandler(cardData: ICard) {
-    updateCardData(bId, cardData);
+  function updateCardHandler(
+    cardId: string,
+    title: string,
+    description: string,
+  ) {
+    updateCardData(bId, cardId, title, description);
   }
   function createCard(name: string, list: string) {
     if (!String(name) || !String(list)) return;
-    createInitialCard(bId, { name, list });
+    createInitialCard(bId, name, list);
   }
   function dragEndHandle(e: any) {
     if (!e.destination) return;
@@ -99,6 +109,9 @@ export default function BoardSlug({
   function permissionListHandler(userIds: string) {
     const trimUser = userIds.split(',').map((userId) => userId.trim());
     changeBoard(bId, 'permissionList', trimUser);
+  }
+  function changeListTitleHandler(listId: string, listTitle: string) {
+    changeListTitle(bId, listId, listTitle);
   }
 
   async function deleteBoardHandler() {
@@ -156,6 +169,7 @@ export default function BoardSlug({
             {...provided.droppableProps}>
             {currentList.map((column, index) => (
               <Column
+                changeListTitle={changeListTitleHandler}
                 createCard={createCard}
                 title={column.title}
                 id={column.id}

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -6,7 +6,6 @@ export default function ProtectedRoute({ router, children }) {
   let unprotectedRoutes = ['/', '/boards/[slug]'];
   let pathIsProtected = unprotectedRoutes.indexOf(router.pathname) === -1;
   if (loading) return null;
-  console.log(router.pathname);
 
   if (typeof window !== 'undefined' && !session && pathIsProtected) {
     router.push('/');

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,4 @@
 export const BASE_URL = '';
 export const BOARDS_COLLECTION = 'boards';
+export const LISTS_COLLECTION = 'lists';
+export const CARDS_COLLECTION = 'cards';

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,4 +1,4 @@
-import { MongoClient, ObjectId } from 'mongodb';
+import { MongoClient } from 'mongodb';
 
 const { DATABASE_URL, MONGODB_DB } = process.env;
 
@@ -53,72 +53,11 @@ export async function insert(collection: string, data: any): Promise<string> {
   return insertReturn.insertedId;
 }
 
-export async function removeById(
-  collection: string,
-  id: ObjectId,
-  authorId: ObjectId,
-): Promise<boolean> {
-  if (!cached.conn) {
-    await connectToDB();
-  }
-  const insertReturn = await cached.conn.db
-    .collection(collection)
-    .deleteOne({ _id: id, author: authorId });
-  if (insertReturn.deletedCount > 0) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-export async function updateById(
-  collection: string,
-  id: ObjectId,
-  authorId: ObjectId,
-  newData: any,
-): Promise<boolean> {
-  if (!cached.conn) {
-    await connectToDB();
-  }
-  const updateReturn = await cached.conn.db.collection(collection).updateOne(
-    { _id: id, author: authorId },
-    {
-      $set: newData,
-    },
-  );
-  if (updateReturn.modifiedCount > 0) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
-export async function updatePushById(
-  collection: string,
-  id: ObjectId,
-  authorId: ObjectId,
-  newData: any,
-): Promise<boolean> {
-  if (!cached.conn) {
-    await connectToDB();
-  }
-  const updateReturn = await cached.conn.db.collection(collection).updateOne(
-    { _id: id, author: authorId },
-    {
-      $push: newData,
-    },
-  );
-  if (updateReturn.modifiedCount > 0) {
-    return true;
-  } else {
-    return false;
-  }
-}
-
 export async function find(
   collection: string,
   filter = {} as any,
   projection = [] as any,
+  sort = {} as any,
 ): Promise<any[]> {
   if (!cached.conn) {
     await connectToDB();
@@ -129,6 +68,44 @@ export async function find(
     .collection(collection)
     .find(filter)
     .project(projectionObj)
+    .sort(sort)
     .toArray();
   return findReturn.map(({ _id, ...item }) => ({ id: _id, ...item }));
+}
+
+export async function update(
+  collection: string,
+  filter = {} as Object,
+  newData: any,
+): Promise<boolean> {
+  if (!cached.conn) {
+    await connectToDB();
+  }
+  const updateReturn = await cached.conn.db
+    .collection(collection)
+    .updateOne(filter, {
+      $set: newData,
+    });
+  if (updateReturn.modifiedCount > 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+export async function remove(
+  collection: string,
+  filter = {} as Object,
+): Promise<boolean> {
+  if (!cached.conn) {
+    await connectToDB();
+  }
+  const insertReturn = await cached.conn.db
+    .collection(collection)
+    .deleteOne(filter);
+  if (insertReturn.deletedCount > 0) {
+    return true;
+  } else {
+    return false;
+  }
 }

--- a/src/utils/idGenerator.ts
+++ b/src/utils/idGenerator.ts
@@ -1,0 +1,4 @@
+export const idGenerator = (): string =>
+  Math.random().toString(10).substr(2, 9) +
+  '-' +
+  Math.random().toString(10).substr(2, 9);


### PR DESCRIPTION
This refactor is meant to simplify not only existing logic but also should simplify for future changes. Instead of using nested documents, it aims to make lists and cards into its own collection (table, in SQL). A downside of this change is needing to make multiple queries when initially fetching a board, one way to mitigate is to use refs, but I've chosen to ignore this for now.

To give a visual representation, the old database was structured like this:
- Board
  - Title
  - Author
   - Lists
      - List id, name, etc.
   - Cards
      - Card id, name, etc. 

The new way aims to be this way:
- Board
  - Title
  - Author
- Lists
   - id
   - name
 - Cards
    -  id
    -  name 
